### PR TITLE
Get tests to pass using indexeddb instead of local-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bs58": "^3.0.0",
     "chai": "^3.4.1",
     "fs-blob-store": "^5.2.1",
+    "idb-plus-blob-store": "^1.0.0",
     "istanbul": "^0.4.1",
     "karma": "^0.13.19",
     "karma-chrome-launcher": "^0.2.2",
@@ -44,7 +45,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.4.4",
     "standard": "^5.1.1",
-    "webpack": "^1.12.11"
+    "webpack": "github:diasdavid/webpack#webpack-1"
   },
   "dependencies": {
     "bl": "^1.0.0",

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -14,7 +14,7 @@ exports.setUp = (basePath, blobStore, locks) => {
           }
           var result
           try {
-            result = JSON.parse(config)
+            result = JSON.parse(config.toString())
           } catch (err) {
             return callback(err)
           }

--- a/src/stores/datastore.js
+++ b/src/stores/datastore.js
@@ -3,7 +3,7 @@ const PREFIX_LENGTH = 8
 exports = module.exports
 
 exports.setUp = (basePath, blobStore, locks) => {
-  var store = blobStore(basePath + '/blocks/')
+  var store = blobStore(basePath + '/blocks')
 
   return {
     createReadStream: multihash => {


### PR DESCRIPTION
## Issues

- [x] Writes are not flushed when the write stream `finish`es. Fixed in idb-plus-blob-store
- [x] At the moment reads are failing because of https://github.com/feross/typedarray-to-buffer/issues/5 Fixed using https://github.com/webpack/webpack/pull/1931
- [x] Cleanup handling of pathing issues for the store names

