### PR TITLE
Use buffer-loader on tests instead of raw-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "async": "^1.5.2",
     "bl": "^1.0.0",
     "bs58": "^3.0.0",
+    "buffer-loader": "^0.0.1",
     "chai": "^3.4.1",
     "fs-blob-store": "^5.2.1",
     "idb-plus-blob-store": "^1.0.0",
@@ -42,7 +43,6 @@
     "mocha": "^2.3.4",
     "ncp": "^2.0.0",
     "pre-commit": "^1.1.1",
-    "raw-loader": "^0.5.1",
     "rimraf": "^2.4.4",
     "standard": "^5.1.1",
     "webpack": "github:diasdavid/webpack#webpack-1"

--- a/tests/browser-tests.js
+++ b/tests/browser-tests.js
@@ -6,7 +6,7 @@ const tests = require('./repo-test')
 const _ = require('lodash')
 const IPFSRepo = require('../src')
 
-const repoContext = require.context('raw!./test-repo', true)
+const repoContext = require.context('buffer!./test-repo', true)
 
 const idb = window.indexedDB ||
         window.mozIndexedDB ||
@@ -16,6 +16,7 @@ const idb = window.indexedDB ||
 idb.deleteDatabase('ipfs')
 idb.deleteDatabase('ipfs/blocks')
 
+// TODO use arrow funtions again when https://github.com/webpack/webpack/issues/1944 is fixed
 describe('IPFS Repo Tests on the Browser', function () {
   before(function (done) {
     var repoData = []

--- a/tests/repo-test.js
+++ b/tests/repo-test.js
@@ -9,10 +9,10 @@ const isNode = !global.window
 
 const fileA = isNode
   ? fs.readFileSync(process.cwd() + '/tests/test-repo/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data')
-  : new Buffer(require('raw!./test-repo/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data'))
+  : require('buffer!./test-repo/blocks/12207028/122070286b9afa6620a66f715c7020d68af3d10e1a497971629c07606bfdb812303d.data')
 
 module.exports = function (repo) {
-  describe('IPFS Repo Tests', () => {
+  describe('IPFS Repo Tests', function () {
     it('check if Repo exists', done => {
       repo.exists((err, exists) => {
         expect(err).to.not.exist
@@ -105,10 +105,10 @@ module.exports = function (repo) {
       })
     })
 
-    describe('datastore', () => {
+    describe('datastore', function () {
       const baseFileHash = 'QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe'
 
-      it('reads block', done => {
+      it('reads block', function (done) {
         const buf = new Buffer(base58.decode(baseFileHash))
         repo.datastore.createReadStream(buf)
           .pipe(bl((err, data) => {
@@ -118,7 +118,7 @@ module.exports = function (repo) {
           }))
       })
 
-      it('write a block', done => {
+      it('write a block', function (done) {
         const rnd = 'QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVtesthash'
         const mh = new Buffer(base58.decode(rnd))
         const data = new Buffer('Oh the data')
@@ -130,7 +130,7 @@ module.exports = function (repo) {
         }).end(data)
       })
 
-      it('block exists', done => {
+      it('block exists', function (done) {
         const buf = new Buffer(base58.decode(baseFileHash))
 
         repo.datastore.exists(buf, (err, exists) => {
@@ -140,7 +140,7 @@ module.exports = function (repo) {
         })
       })
 
-      it('check for non existent block', done => {
+      it('check for non existent block', function (done) {
         const buf = new Buffer('random buffer')
 
         repo.datastore.exists(buf, (err, exists) => {
@@ -150,7 +150,7 @@ module.exports = function (repo) {
         })
       })
 
-      it('remove a block', done => {
+      it('remove a block', function (done) {
         const buf = new Buffer(base58.decode(baseFileHash))
         repo.datastore.remove(buf, (err) => {
           expect(err).to.not.exist


### PR DESCRIPTION
Makes file buffers have the same content and length on both node and browser. 

Related to https://github.com/ipfs/js-ipfs/pull/62 and https://github.com/ipfs/js-ipfs/pull/61