### PR TITLE
No longer considers a non-existant repo an error.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,21 +4,24 @@ exports = module.exports = Repo
 
 function Repo (repoPath, options) {
   this.init = (config, callback) => {
-    if (this.exists()) {
-      throw new Error('Repo already exists')
-    }
+    this.exists((err, exists) => {
+      if (err) { throw err }
+      if (exists) { throw new Error('Repo already exists') }
+      throw new Error('not implemented')
+    })
   }
 
   this.locks = stores
                   .locks
                   .setUp(repoPath, options.stores.locks)
 
-  this.exists = callback => {
-    this.version.get((err, version) => {
+  this.exists = (callback) => {
+    this.version.exists((err, exists) => {
       if (err) {
-        return callback(new Error('Repo does not exist'))
+        callback(new Error('repo does not exist'), false)
+      } else {
+        callback(null, exists)
       }
-      callback(null, true)
     })
   }
 

--- a/src/stores/version.js
+++ b/src/stores/version.js
@@ -6,6 +6,9 @@ exports.setUp = (basePath, blobStore, locks) => {
   var store = blobStore(basePath)
 
   return {
+    exists: callback => {
+      store.exists('version', callback)
+    },
     get: callback => {
       store
         .createReadStream('version')

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -6,7 +6,7 @@ const rimraf = require('rimraf')
 
 const IPFSRepo = require('../src')
 
-describe('IPFS Repo Testson on Node.js', () => {
+describe('IPFS Repo Tests on on Node.js', () => {
   const testRepoPath = __dirname + '/test-repo'
   const date = Date.now().toString()
   const repoPath = testRepoPath + date


### PR DESCRIPTION
Calling repo.exists() on a repo that doesn't exist would return an error
rather than false, which would also mask whatever the underlying error
really was.