### PR TITLE
Rename stores

### DIFF
--- a/src/default-options-browser.js
+++ b/src/default-options-browser.js
@@ -4,6 +4,7 @@
 module.exports = {
   blockStore: require('datastore-level'),
   blockStoreOptions: { db: require('level-js') },
-  dataStore: require('level-js'),
+  dataStore: require('datastore-level'),
+  dataStoreOptions: { db: require('level-js') },
   sharding: false
 }

--- a/src/default-options-browser.js
+++ b/src/default-options-browser.js
@@ -2,10 +2,8 @@
 
 // Default configuration for a repo in the browser
 module.exports = {
-  fs: require('datastore-level'),
-  sharding: false,
-  fsOptions: {
-    db: require('level-js')
-  },
-  level: require('level-js')
+  blockStore: require('datastore-level'),
+  blockStoreOptions: { db: require('level-js') },
+  dataStore: require('level-js'),
+  sharding: false
 }

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -2,7 +2,7 @@
 
 // Default configuration for a repo in node.js
 module.exports = {
-  fs: require('datastore-fs'),
-  level: require('leveldown'),
-  sharding: true
+  blockStore: require('datastore-fs'),
+  dataStore: require('datastore-level'),
+  dataStoreOptions: { db: require('leveldown') }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -199,9 +199,8 @@ class IpfsRepo {
         cb(err)
       }),
       (cb) => this.store.close(cb),
-      (cb) => console.log('closing block...') || this._blockStore.close(cb),
+      (cb) => this._blockStore.close(cb),
       (cb) => {
-        console.log('lock:', this.lockfile)
         log('unlocking')
         this.closed = true
         this.lockfile.close(cb)

--- a/src/index.js
+++ b/src/index.js
@@ -127,13 +127,16 @@ class IpfsRepo {
         const DataStore = this.options.dataStore
         const dataStore = new DataStore(path.join(this.path, dataStoreDirectory), this.options.dataStoreOptions)
         log(dataStore)
-        this.store = new MountStore([{
-          prefix: new Key(blockStoreDirectory),
-          datastore: blockStore
-        }, {
-          prefix: new Key('/'),
-          datastore: dataStore
-        }])
+        this.store = new MountStore([
+          {
+            prefix: new Key(blockStoreDirectory),
+            datastore: blockStore
+          },
+          {
+            prefix: new Key('/'),
+            datastore: dataStore
+          }
+        ])
 
         this.blockstore = blockstore(this)
         this.closed = false
@@ -196,8 +199,9 @@ class IpfsRepo {
         cb(err)
       }),
       (cb) => this.store.close(cb),
-      (cb) => this._blockStore.close(cb),
+      (cb) => console.log('closing block...') || this._blockStore.close(cb),
       (cb) => {
+        console.log('lock:', this.lockfile)
         log('unlocking')
         this.closed = true
         this.lockfile.close(cb)

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ const MountStore = core.MountDatastore
 const ShardingStore = core.ShardingDatastore
 
 const Key = require('interface-datastore').Key
-const LevelStore = require('datastore-level')
 const waterfall = require('async/waterfall')
 const series = require('async/series')
 const parallel = require('async/parallel')
@@ -22,8 +21,8 @@ const blockstore = require('./blockstore')
 const log = debug('repo')
 
 const apiFile = new Key('api')
-const flatfsDirectory = 'blocks'
-const levelDirectory = 'datastore'
+const blockStoreDirectory = 'blocks'
+const dataStoreDirectory = 'datastore'
 const repoVersion = 5
 
 /**
@@ -34,33 +33,25 @@ class IpfsRepo {
   /**
    * @param {string} repoPath - path where the repo is stored
    * @param {object} options - Configuration
-   * @param {Datastore} options.fs
-   * @param {Leveldown} options.level
-   * @param {object} [options.fsOptions={}]
+   * @param {datastore} options.blockStore
+   * @param {datastore} options.dataStore
+   * @param {object} [options.blockStoreOptions={}]
+   * @param {object} [options.dataStoreOptions={}]
    * @param {bool} [options.sharding=true] - Enable sharding (flatfs on disk), not needed in the browser.
    * @param {string} [options.lock='fs'] - Either `fs` or `memory`.
    */
   constructor (repoPath, options) {
     assert.equal(typeof repoPath, 'string', 'missing repoPath')
 
-    if (options == null) {
-      options = require('./default-options')
-    }
-
+    const defaultOptions = require('./default-options')
     this.closed = true
     this.path = repoPath
-    this.options = Object.assign({
-      sharding: true,
-      lock: 'fs'
-    }, options)
-    this._fsOptions = Object.assign({}, options.fsOptions)
-    const FsStore = this.options.fs
-    this._fsStore = new FsStore(this.path, Object.assign({}, this._fsOptions, {
-      extension: ''
-    }))
+    this.options = Object.assign({ lock: 'memory', sharding: true }, options || defaultOptions)
+    const BlockStore = this.options.blockStore
+    this._blockStore = new BlockStore(this.path, this.options.blockStoreOptions)
 
-    this.version = version(this._fsStore)
-    this.config = config(this._fsStore)
+    this.version = version(this._blockStore)
+    this.config = config(this._blockStore)
 
     if (this.options.lock === 'memory') {
       this._locker = require('./lock-memory')
@@ -82,7 +73,7 @@ class IpfsRepo {
     log('initializing at: %s', this.path)
 
     series([
-      (cb) => this._fsStore.open((err) => {
+      (cb) => this._blockStore.open((err) => {
         if (err && err.message === 'Already open') {
           return cb()
         }
@@ -108,7 +99,7 @@ class IpfsRepo {
 
     // check if the repo is already initialized
     waterfall([
-      (cb) => this._fsStore.open((err) => {
+      (cb) => this._blockStore.open((err) => {
         if (err && err.message === 'Already open') {
           return cb()
         }
@@ -121,8 +112,8 @@ class IpfsRepo {
         this.lockfile = lck
 
         log('creating flatfs')
-        const FsStore = this.options.fs
-        const s = new FsStore(path.join(this.path, flatfsDirectory), this._fsOptions)
+        const BlockStore = this.options.blockStore
+        const s = new BlockStore(path.join(this.path, blockStoreDirectory), this.options.blockStoreOptions)
 
         if (this.options.sharding) {
           const shard = new core.shard.NextToLast(2)
@@ -131,16 +122,17 @@ class IpfsRepo {
           cb(null, s)
         }
       },
-      (flatfs, cb) => {
+      (blockStore, cb) => {
         log('Flatfs store opened')
+        const DataStore = this.options.dataStore
+        const dataStore = new DataStore(path.join(this.path, dataStoreDirectory), this.options.dataStoreOptions)
+        log(dataStore)
         this.store = new MountStore([{
-          prefix: new Key(flatfsDirectory),
-          datastore: flatfs
+          prefix: new Key(blockStoreDirectory),
+          datastore: blockStore
         }, {
           prefix: new Key('/'),
-          datastore: new LevelStore(path.join(this.path, levelDirectory), {
-            db: this.options.level
-          })
+          datastore: dataStore
         }])
 
         this.blockstore = blockstore(this)
@@ -197,14 +189,14 @@ class IpfsRepo {
 
     log('closing at: %s', this.path)
     series([
-      (cb) => this._fsStore.delete(apiFile, (err) => {
+      (cb) => this._blockStore.delete(apiFile, (err) => {
         if (err && err.message.startsWith('ENOENT')) {
           return cb()
         }
         cb(err)
       }),
       (cb) => this.store.close(cb),
-      (cb) => this._fsStore.close(cb),
+      (cb) => this._blockStore.close(cb),
       (cb) => {
         log('unlocking')
         this.closed = true
@@ -235,7 +227,7 @@ class IpfsRepo {
    * @returns {void}
    */
   setApiAddress (addr, callback) {
-    this._fsStore.put(apiFile, Buffer.from(addr.toString()), callback)
+    this._blockStore.put(apiFile, Buffer.from(addr.toString()), callback)
   }
 
   /**
@@ -245,7 +237,7 @@ class IpfsRepo {
    * @returns {void}
    */
   apiAddress (callback) {
-    this._fsStore.get(apiFile, (err, rawAddr) => {
+    this._blockStore.get(apiFile, (err, rawAddr) => {
       if (err) {
         return callback(err)
       }

--- a/test/node.js
+++ b/test/node.js
@@ -20,9 +20,9 @@ describe('IPFS Repo Tests on on Node.js', () => {
   }, {
     name: 'memory',
     opts: {
-      fs: require('interface-datastore').MemoryDatastore,
-      level: require('memdown'),
-      lock: 'memory'
+      blockStore: require('interface-datastore').MemoryDatastore,
+      dataStore: require('interface-datastore').MemoryDatastore
+      // dataStore: require('memdown')
     },
     init: true
   }]

--- a/test/node.js
+++ b/test/node.js
@@ -13,35 +13,28 @@ const expect = chai.expect
 const IPFSRepo = require('../src')
 
 describe('IPFS Repo Tests on on Node.js', () => {
-  const repos = [{
-    name: 'default',
-    opts: undefined,
-    init: false
-  }, {
-    name: 'memory',
-    opts: {
-      blockStore: require('interface-datastore').MemoryDatastore,
-      dataStore: require('interface-datastore').MemoryDatastore
-      // dataStore: require('memdown')
+  const repos = [
+    {
+      name: 'default',
+      opts: undefined
     },
-    init: true
-  }]
+    {
+      name: 'memory',
+      opts: {
+        blockStore: require('interface-datastore').MemoryDatastore,
+        dataStore: require('interface-datastore').MemoryDatastore
+      }
+    }
+  ]
   repos.forEach((r) => describe(r.name, () => {
     const testRepoPath = path.join(__dirname, 'test-repo')
     const date = Date.now().toString()
     const repoPath = testRepoPath + '-for-' + date
-
     const repo = new IPFSRepo(repoPath, r.opts)
-
     before((done) => {
       series([
-        (cb) => {
-          if (r.init) {
-            repo.init({}, cb)
-          } else {
-            ncp(testRepoPath, repoPath, cb)
-          }
-        },
+        (cb) => ncp(testRepoPath, repoPath, cb),
+        (cb) => repo.init({}, cb),
         (cb) => repo.open(cb)
       ], done)
     })
@@ -73,7 +66,7 @@ describe('IPFS Repo Tests on on Node.js', () => {
     require('./repo-test')(repo)
     require('./blockstore-test')(repo)
     require('./datastore-test')(repo)
-    if (!r.init) {
+    if (r.name === 'default') {
       require('./interop-test')(repo)
     }
   }))


### PR DESCRIPTION
I'm intending to add a new abstraction for s3 file storage (#135). This is simply a straight up refactor to rename the stores based on their purpose rather than the names of the kinds of storage. In other words, instead of `fs` and `level` the stores are renamed to `block` and `data`.

The s3 storage type will be in another repo and will be very similar to the fs datastore but saving into s3.