### PR TITLE
Chore/remove multiaddr

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
-    "multiaddr": "^2.3.0",
     "safe-buffer": "^5.1.1"
   },
   "license": "MIT",


### PR DESCRIPTION
Removes outdated multiaddr dependency thats causing issues in ipfs - p2p-webrtc* addrs not being recognized

```
protocols-table.js:17 Uncaught Error: no protocol with name: p2p-webrtc-star
    at Protocols (protocols-table.js:17)
    at stringToStringTuples (codec.js:45)
    at stringToBuffer (codec.js:170)
    at Object.fromString (codec.js:178)
    at new Multiaddr (index.js:39)
    at Multiaddr (index.js:27)
    at WebRTCStar._peerDiscovered (index.js:223)
    at Socket.Emitter.emit (index.js:133)
    at Socket.onevent (socket.js:270)
    at Socket.onpacket (socket.js:228)
```