### PR TITLE
Expose the current repo version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -203,6 +203,7 @@ class IpfsRepo {
 }
 
 module.exports = IpfsRepo
+module.exports.repoVersion = repoVersion
 
 function ignoringIf (cond, cb) {
   return (err) => {


### PR DESCRIPTION
Expose the repo version for access even when a repo hasn't been initialized.

discussion: [js-ipfs#1181](https://github.com/ipfs/js-ipfs/pull/1181/files#r163727102)
ref: [js-ipfs#1188](https://github.com/ipfs/js-ipfs/pull/1188)
