### PR TITLE
Implement .stat() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,20 @@ Sets the API address.
 
 * `value` should be a [Multiaddr](https://github.com/multiformats/js-multiaddr) or a String representing a valid one.
 
+### `repo.stat ([options], callback)`
+
+Gets the repo status. 
+
+`options` is an object which might contain the key `human`, which is a boolean indicating whether or not the `repoSize` should be displayed in MiB or not.
+
+`callback` is a function with the signature `function (err, stats)`, where `stats` is an Object with the following keys:
+
+- `numObjects`
+- `repoPath`
+- `repoSize`
+- `version`
+- `storageMax`
+
 ## Notes
 
 - [Explanation of how repo is structured](https://github.com/ipfs/js-ipfs-repo/pull/111#issuecomment-279948247)

--- a/package.json
+++ b/package.json
@@ -56,12 +56,13 @@
   "dependencies": {
     "async": "^2.6.0",
     "base32.js": "~0.1.0",
+    "big.js": "^5.0.3",
     "cids": "~0.5.2",
-    "interface-datastore": "~0.4.2",
     "datastore-core": "~0.4.0",
     "datastore-fs": "~0.4.2",
     "datastore-level": "~0.7.0",
     "debug": "^3.1.0",
+    "interface-datastore": "~0.4.2",
     "ipfs-block": "~0.6.1",
     "level-js": "timkuijsten/level.js#idbunwrapper",
     "leveldown": "^1.7.2",
@@ -69,7 +70,8 @@
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
-    "multiaddr": "^3.0.1"
+    "multiaddr": "^3.0.1",
+    "pull-stream": "^3.6.1"
   },
   "license": "MIT",
   "contributors": [

--- a/src/blockstore.js
+++ b/src/blockstore.js
@@ -8,6 +8,7 @@ const Block = require('ipfs-block')
 const setImmediate = require('async/setImmediate')
 const reject = require('async/reject')
 const CID = require('cids')
+const pull = require('pull-stream')
 
 /**
  * Transform a raw buffer to a base32 encoded key.
@@ -49,6 +50,19 @@ function maybeWithSharding (filestore, options, callback) {
 
 function createBaseStore (store) {
   return {
+    /**
+     * Query the store.
+     *
+     * @param {object} query
+     * @param {function(Error, Array)} callback
+     * @return {void}
+     */
+    query (query, callback) {
+      pull(
+        store.query(query),
+        pull.collect(callback)
+      )
+    },
     /**
      * Get a single block by CID.
      *

--- a/test/node.js
+++ b/test/node.js
@@ -61,6 +61,7 @@ describe('IPFS Repo Tests onNode.js', () => {
     require('./blockstore-test')(repo)
     require('./datastore-test')(repo)
     require('./keystore-test')(repo)
+    require('./stat-test')(repo)
     if (!r.init) {
       require('./interop-test')(repo)
     }

--- a/test/stat-test.js
+++ b/test/stat-test.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+
+module.exports = (repo) => {
+  describe('stat', () => {
+    it('get stats', (done) => {
+      repo.stat((err, stats) => {
+        expect(err).to.not.exist()
+        expect(stats).to.exist()
+        expect(stats).to.have.property('numObjects')
+        expect(stats).to.have.property('version')
+        expect(stats).to.have.property('repoPath')
+        expect(stats).to.have.property('repoSize')
+        expect(stats).to.have.property('storageMax')
+
+        expect(stats.numObjects > '0').to.eql(true)
+        expect(stats.version > '0').to.eql(true)
+        expect(stats.repoSize > '0').to.eql(true)
+        expect(stats.storageMax > '0').to.eql(true)
+        done()
+      })
+    })
+
+    it('get human stats', (done) => {
+      repo.stat({human: true}, (err, stats) => {
+        expect(err).to.not.exist()
+        expect(stats).to.exist()
+        expect(stats).to.have.property('numObjects')
+        expect(stats).to.have.property('version')
+        expect(stats).to.have.property('repoPath')
+        expect(stats).to.have.property('repoSize')
+        expect(stats).to.have.property('storageMax')
+
+        expect(stats.numObjects > '0').to.eql(true)
+        expect(stats.version > '0').to.eql(true)
+        expect(stats.repoSize > '0').to.eql(true)
+        expect(stats.storageMax > '0').to.eql(true)
+        done()
+      })
+    })
+  })
+}


### PR DESCRIPTION
To implement this, I take a look at [Go's repo.stat implementation](https://github.com/ipfs/go-ipfs/blob/4c392928b48db4cdd8853234202ab97c78e3d56b/core/corerepo/stat.go) and I basically do the same on each one except on `repoSize`.

- For `numObjects` I use the number of blocks on the Blockstore
- For `repoPath` I just used `this.path`
- For `version` I use `this.version.get`
- For `storageMax` I use the config `Datastore.StorageMax` or the maximum integer number.
- For `repoSize` I sum the number of bytes of the blocks and their keys from the Blockstore + the same for the Datastore and the Keystore. This doesn't count with `api` and ´config` files' size but it won't differ much from the real size. 

I also added a simple test.