### PR TITLE
Feat/is initialized error code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ yarn.lock
 package-lock.json
 
 test/test-repo-for*
-
+.vscode
+.eslintrc
 # Logs
 logs
 *.log

--- a/src/index.js
+++ b/src/index.js
@@ -213,11 +213,11 @@ class IpfsRepo {
       (err, res) => {
         log('init', err, res)
         if (err) {
-          return callback(err)
-        }
-
-        if (!res.config) {
-          return callback(new Error('repo is not initialized yet'))
+          return callback(Object.assign(new Error('repo is not initialized yet'),
+            {
+              code: 'ERR_REPO_NOT_INITIALIZED',
+              path: this.path
+            }))
         }
         callback()
       }


### PR DESCRIPTION
_isInitialized is used in several other repos to check the repo even being a pseudo private method.

The error should be uniform for easier handling and not whatever `this.config.exists(cb)` or `this.version.check(repoVersion, cb)` returns on error.

Also using error codes as node.js does, handling errors becomes much easier. 