### PR TITLE
fix: expose errors to resolve need for antipattern require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -345,6 +345,7 @@ function getSize (queryFn, callback) {
 
 module.exports = IpfsRepo
 module.exports.repoVersion = repoVersion
+module.exports.errors = ERRORS
 
 function ignoringIf (cond, cb) {
   return (err) => {


### PR DESCRIPTION
Allow for `require('ipfs-repo').errors` instead of `require('ipfs-repo/src/errors')`