### PR TITLE
Support for swarm keys

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 test/test-repo/** text eol=lf
+test/fixtures/** text eol=lf

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,3 +1,4 @@
 'use strict'
 
 exports.ERR_REPO_NOT_INITIALIZED = 'ERR_REPO_NOT_INITIALIZED'
+exports.SWARM_KEY_NOT_FOUND = 'No swarm key found'

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const path = require('path')
 const debug = require('debug')
 const Big = require('bignumber.js')
 const pull = require('pull-stream')
+const Key = require('interface-datastore').Key
 
 const backends = require('./backends')
 const version = require('./version')
@@ -321,6 +322,22 @@ class IpfsRepo {
         numObjects: results.blocks.count,
         repoSize: size
       })
+    })
+  }
+
+  /**
+   * Gets the swarm.key buffer, if it exists
+   *
+   * @param {function(Error, Buffer)} callback
+   * @returns {void}
+   */
+  swarmKey (callback) {
+    const swarmKeyKey = new Key('swarm.key')
+    this.root.get(swarmKeyKey, (err, swarmKeyBuffer) => {
+      if (err) {
+        return callback(new Error(ERRORS.SWARM_KEY_NOT_FOUND))
+      }
+      callback(null, swarmKeyBuffer)
     })
   }
 }

--- a/test/fixtures/pnet-repo/swarm.key
+++ b/test/fixtures/pnet-repo/swarm.key
@@ -1,0 +1,3 @@
+/key/swarm/psk/1.0.0/
+/base16/
+a4ec738d91ab0fbce75dfc29e8f5b6d75830aff1b76afeb51cd602a4b764aee8

--- a/test/node.js
+++ b/test/node.js
@@ -13,6 +13,7 @@ const IPFSRepo = require('../src')
 
 describe('IPFS Repo Tests onNode.js', () => {
   require('./options-test')
+  require('./pnet-test')
 
   const customLock = {
     lockName: 'test.lock',
@@ -88,7 +89,9 @@ describe('IPFS Repo Tests onNode.js', () => {
           }
         },
         (cb) => repo.open(cb)
-      ], done)
+      ], (err) => {
+        done(err)
+      })
     })
 
     after((done) => {

--- a/test/pnet-test.js
+++ b/test/pnet-test.js
@@ -1,0 +1,55 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const path = require('path')
+const ncp = require('ncp').ncp
+const rimraf = require('rimraf')
+const series = require('async/series')
+
+const Repo = require('../')
+const Errors = require('../').errors
+
+describe('private network', () => {
+  describe('swarm key', () => {
+    const repoPath = path.join(__dirname, 'slash', 'path')
+    const swarmRepoPath = path.join(__dirname, 'fixtures/pnet-repo')
+
+    afterEach(() => {
+      rimraf.sync(repoPath)
+    })
+
+    it('returns an error if no swarm key is found', (done) => {
+      const repo = new Repo(repoPath)
+
+      repo.swarmKey((err, swarmKeyBuffer) => {
+        expect(swarmKeyBuffer).to.not.exist()
+        expect(err).to.include({
+          message: Errors.SWARM_KEY_NOT_FOUND
+        })
+        done()
+      })
+    })
+
+    it('gets the swarm.key', (done) => {
+      const repo = new Repo(repoPath)
+
+      series([
+        (cb) => {
+          // copy the swarm key to the repo root
+          ncp(swarmRepoPath, repoPath, cb)
+        },
+        (cb) => {
+          repo.swarmKey((err, swarmKeyBuffer) => {
+            expect(err).to.not.exist()
+            expect(Buffer.isBuffer(swarmKeyBuffer)).to.equal(true)
+            expect(swarmKeyBuffer.byteLength).to.equal(95)
+            cb()
+          })
+        }
+      ], done)
+    })
+  })
+})


### PR DESCRIPTION
This gives ipfs-repo the ability to return swarm.key files that are stored in its root. This is necessary for autostarting an ipfs node with a private network swarm.

This will make it possible to implement the [pnet protector](https://github.com/libp2p/js-libp2p-pnet) in js-ipfs.