### PR TITLE
fix: fix lock for node 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "debug": "^4.1.0",
     "interface-datastore": "~0.6.0",
     "ipfs-block": "~0.7.1",
-    "lock-me": "^1.0.4",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
     "multiaddr": "^5.0.0",
+    "proper-lockfile": "^3.2.0",
     "pull-stream": "^3.6.9",
     "sort-keys": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -189,20 +189,6 @@ class IpfsRepo {
   }
 
   /**
-   * Gets the status of the lock on the repo
-   *
-   * @param {string} path
-   * @param {function(Error, boolean)} callback
-   * @returns {void}
-   */
-  _isLocked (path, callback) {
-    if (this._locker) {
-      return this._locker.locked(path, callback)
-    }
-    callback(null, false)
-  }
-
-  /**
    * Check if the repo is already initialized.
    *
    * @private

--- a/src/lock.js
+++ b/src/lock.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const debug = require('debug')
-const fs = require('fs')
 const { lock } = require('proper-lockfile')
 
 const log = debug('repo:lock')

--- a/src/lock.js
+++ b/src/lock.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const debug = require('debug')
 const fs = require('fs')
-const { lock, check } = require('proper-lockfile')
+const { lock } = require('proper-lockfile')
 
 const log = debug('repo:lock')
 
@@ -27,31 +27,6 @@ exports.lock = (dir, callback) => {
           .then(() => cb())
           .catch(err => cb(err))
       }})
-    })
-    .catch(err => callback(err))
-}
-
-/**
- * Check if the repo in the given directory is locked.
- *
- * @param {string} dir
- * @param {function(Error, bool)} callback
- * @returns {void}
- */
-exports.locked = (dir, callback) => {
-  const file = path.join(dir, lockFile)
-  log('checking lock: %s')
-
-  if (!fs.existsSync(file)) {
-    log('file does not exist: %s', file)
-  }
-
-  check(dir, { lockfilePath: file })
-    .then(islocked => {
-      if (islocked) {
-        return callback(null, true)
-      }
-      callback(null, false)
     })
     .catch(err => callback(err))
 }

--- a/test/lock-test.js
+++ b/test/lock-test.js
@@ -32,7 +32,7 @@ module.exports = (repo) => {
       const mochaExceptionHandler = process.listeners('uncaughtException').pop()
       process.removeListener('uncaughtException', mochaExceptionHandler)
       process.once('uncaughtException', function (err) {
-        expect(err.message).to.match(/already held|IO error/)
+        expect(err.message).to.match(/already held|IO error|already being hold/)
       })
 
       series([
@@ -49,7 +49,7 @@ module.exports = (repo) => {
       ], function (err) {
         // There will be no listeners if the uncaughtException was triggered
         if (process.listeners('uncaughtException').length > 0) {
-          expect(err.message).to.match(/already locked|already held|ENOENT/)
+          expect(err.message).to.match(/already locked|already held|already being hold|ELOCKED/)
         }
 
         // Reset listeners to maintain test integrity

--- a/test/node.js
+++ b/test/node.js
@@ -43,29 +43,34 @@ describe('IPFS Repo Tests onNode.js', () => {
     }
   }
 
-  const repos = [{
-    name: 'default inited',
-    opts: undefined,
-    init: true
-  }, {
-    name: 'memory',
-    opts: {
-      fs: require('interface-datastore').MemoryDatastore,
-      level: require('memdown'),
-      lock: 'memory'
+  const repos = [
+    {
+      name: 'default inited',
+      opts: undefined,
+      init: true
     },
-    init: true
-  }, {
-    name: 'custom locker',
-    opts: {
-      lock: customLock
+    {
+      name: 'memory',
+      opts: {
+        fs: require('interface-datastore').MemoryDatastore,
+        level: require('memdown'),
+        lock: 'memory'
+      },
+      init: true
     },
-    init: true
-  }, {
-    name: 'default existing',
-    opts: undefined,
-    init: false
-  }]
+    {
+      name: 'custom locker',
+      opts: {
+        lock: customLock
+      },
+      init: true
+    },
+    {
+      name: 'default existing',
+      opts: undefined,
+      init: false
+    }
+  ]
   repos.forEach((r) => describe(r.name, () => {
     const testRepoPath = path.join(__dirname, 'test-repo')
     const date = Date.now().toString()


### PR DESCRIPTION
This PR swaps lock-me for proper-lockfile which fixes compat with node 11 and also brings others improvements https://github.com/moxystudio/node-proper-lockfile.
- better support for network file systems 
- staleness support
- better clean up for process shutdown

ref: https://github.com/ipfs/js-ipfs/issues/1700