### PR TITLE
fix: fix staleness check

### DIFF
--- a/src/lock.js
+++ b/src/lock.js
@@ -5,8 +5,18 @@ const debug = require('debug')
 const { lock } = require('proper-lockfile')
 
 const log = debug('repo:lock')
-
 const lockFile = 'repo.lock'
+
+/**
+ * Duration in milliseconds in which the lock is considered stale
+ * @see https://github.com/moxystudio/node-proper-lockfile#lockfile-options
+ * The default value of 10000 was too low for ipfs and sometimes `proper-lockfile`
+ * would throw an exception because it couldn't update the lock file mtime within
+ * the 10s threshold. @see https://github.com/ipfs/js-ipfs-repo/pull/182
+ * Increasing to 20s is a temporary fix a permanent fix should be implemented in
+ * the future.
+ */
+const STALE_TIME = 20000
 
 /**
  * Lock the repo in the given dir.
@@ -19,7 +29,7 @@ exports.lock = (dir, callback) => {
   const file = path.join(dir, lockFile)
   log('locking %s', file)
 
-  lock(dir, {lockfilePath: file, stale: 20000})
+  lock(dir, {lockfilePath: file, stale: STALE_TIME})
     .then(release => {
       callback(null, {close: (cb) => {
         release()

--- a/src/lock.js
+++ b/src/lock.js
@@ -19,7 +19,7 @@ exports.lock = (dir, callback) => {
   const file = path.join(dir, lockFile)
   log('locking %s', file)
 
-  lock(dir, {lockfilePath: file})
+  lock(dir, {lockfilePath: file, stale: 20000})
     .then(release => {
       callback(null, {close: (cb) => {
         release()


### PR DESCRIPTION
This PR fixes this https://github.com/ipfs/js-ipfs-repo/pull/181#issuecomment-440218312 

For context the problem isn't about that stack trace, the problem is about the staleness checks https://github.com/moxystudio/node-proper-lockfile#design. 
The lockfile mtime is updated periodically (5s) to prevent staleness, and there's a threshold of up to 10s to mark a lock as stale. 

What happens is that ipfs some how locks the event loop for so long that `proper-lockfile` marks the lock as compromised because it takes more than 5s to update mtime again and so we hit the limit of 10s. Hope this makes sense lol :)

This fix just increases the stale threshold to 20s and that should be enough, but its a naive fix and if we need to further increase this threshold we should really dig into it more. 

To give an example of what this threshold means, if we have a long running ipfs daemon that critically crashes meaning no cleaning is made (lock file still there) we can't spawn another for the next 20s without manually deleting the lock file so any systemd like system that restart the process after a crash will not work!

