### PR TITLE
feat: cid agnostic blockstore .get and .has

### DIFF
--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@
 const Repo = require('ipfs-repo')
 const repo = new Repo('/Users/awesome/.jsipfs')
 
-repo.init({my: 'config'}, (err) => {
+repo.init({ my: 'config' }, (err) => {
   if (err) {
     throw err
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "async": "^2.6.1",
     "base32.js": "~0.1.0",
     "big.js": "^5.2.2",
-    "cids": "~0.5.5",
+    "cids": "~0.5.7",
     "datastore-core": "~0.6.0",
     "datastore-fs": "~0.7.0",
     "datastore-level": "~0.10.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^15.3.1",
+    "aegir": "^17.1.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "lodash": "^4.17.11",
-    "memdown": "^1.4.1",
+    "memdown": "^3.0.0",
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.1",
     "ncp": "^2.0.0",
@@ -58,11 +58,11 @@
     "datastore-level": "~0.10.0",
     "debug": "^4.1.0",
     "interface-datastore": "~0.6.0",
-    "ipfs-block": "~0.7.1",
+    "ipfs-block": "~0.8.0",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.set": "^4.3.2",
-    "multiaddr": "^5.0.0",
+    "multiaddr": "^6.0.0",
     "proper-lockfile": "^3.2.0",
     "pull-stream": "^3.6.9",
     "sort-keys": "^2.0.0"

--- a/src/blockstore.js
+++ b/src/blockstore.js
@@ -88,14 +88,12 @@ function createBaseStore (store) {
             if (!otherCid) return callback(err)
 
             const otherKey = cidToDsKey(otherCid)
-            store.get(otherKey, (err, blockData) => {
+            return store.get(otherKey, (err, blockData) => {
               if (err) return callback(err)
 
-              const block = new Block(blockData, otherCid)
-
-              store.put(block, (err) => {
+              store.put(key, blockData, (err) => {
                 if (err) return callback(err)
-                callback(null, block)
+                callback(null, new Block(blockData, cid))
               })
             })
           }
@@ -166,6 +164,7 @@ function createBaseStore (store) {
         if (err) return callback(err)
         if (exists) return callback(null, true)
 
+        // If not found, we try with the other CID version.
         const otherCid = cidToOtherVersion(cid)
         if (!otherCid) return callback(null, false)
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ class IpfsRepo {
    * @param {object} options - Configuration
    */
   constructor (repoPath, options) {
-    assert.equal(typeof repoPath, 'string', 'missing repoPath')
+    assert.strictEqual(typeof repoPath, 'string', 'missing repoPath')
 
     this.options = buildOptions(options)
     this.closed = true
@@ -170,7 +170,7 @@ class IpfsRepo {
         return callback(err, null)
       }
 
-      assert.equal(typeof lockfile.close, 'function', 'Locks must have a close method')
+      assert.strictEqual(typeof lockfile.close, 'function', 'Locks must have a close method')
       callback(null, lockfile)
     })
   }
@@ -273,7 +273,7 @@ class IpfsRepo {
       options = {}
     }
 
-    options = Object.assign({}, {human: false}, options)
+    options = Object.assign({}, { human: false }, options)
 
     parallel({
       storageMax: (cb) => this.config.get('Datastore.StorageMax', (err, max) => {

--- a/src/lock.js
+++ b/src/lock.js
@@ -29,13 +29,15 @@ exports.lock = (dir, callback) => {
   const file = path.join(dir, lockFile)
   log('locking %s', file)
 
-  lock(dir, {lockfilePath: file, stale: STALE_TIME})
+  lock(dir, { lockfilePath: file, stale: STALE_TIME })
     .then(release => {
-      callback(null, {close: (cb) => {
-        release()
-          .then(() => cb())
-          .catch(err => cb(err))
-      }})
+      callback(null, {
+        close: (cb) => {
+          release()
+            .then(() => cb())
+            .catch(err => cb(err))
+        }
+      })
     })
     .catch(err => callback(err))
 }

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -193,6 +193,46 @@ module.exports = (repo) => {
           done()
         })
       })
+
+      it('should have block stored under v0 CID with a v1 CID', done => {
+        const data = Buffer.from(`TEST${Date.now()}`)
+
+        multihashing(data, 'sha2-256', (err, hash) => {
+          if (err) return done(err)
+
+          const cid = new CID(hash)
+
+          repo.blocks.put(new Block(data, cid), err => {
+            if (err) return done(err)
+
+            repo.blocks.has(cid.toV1(), (err, exists) => {
+              expect(err).to.not.exist()
+              expect(exists).to.eql(true)
+              done()
+            })
+          })
+        })
+      })
+
+      it('should have block stored under v1 CID with a v0 CID', done => {
+        const data = Buffer.from(`TEST${Date.now()}`)
+
+        multihashing(data, 'sha2-256', (err, hash) => {
+          if (err) return done(err)
+
+          const cid = new CID(1, 'dag-pb', hash)
+
+          repo.blocks.put(new Block(data, cid), err => {
+            if (err) return done(err)
+
+            repo.blocks.has(cid.toV0(), (err, exists) => {
+              expect(err).to.not.exist()
+              expect(exists).to.eql(true)
+              done()
+            })
+          })
+        })
+      })
     })
 
     describe('.delete', () => {

--- a/test/repo-test.js
+++ b/test/repo-test.js
@@ -32,10 +32,10 @@ module.exports = (repo) => {
 
       it('set config', (done) => {
         series([
-          (cb) => repo.config.set({a: 'b'}, cb),
+          (cb) => repo.config.set({ a: 'b' }, cb),
           (cb) => repo.config.get((err, config) => {
             if (err) return cb(err)
-            expect(config).to.deep.equal({a: 'b'})
+            expect(config).to.deep.equal({ a: 'b' })
             cb()
           })
         ], done)
@@ -54,7 +54,7 @@ module.exports = (repo) => {
           (cb) => repo.config.set('c.x', 'd', cb),
           (cb) => repo.config.get((err, config) => {
             if (err) return cb(err)
-            expect(config).to.deep.equal({a: 'b', c: { x: 'd' }})
+            expect(config).to.deep.equal({ a: 'b', c: { x: 'd' } })
             cb()
           })
         ], done)

--- a/test/stat-test.js
+++ b/test/stat-test.js
@@ -26,7 +26,7 @@ module.exports = (repo) => {
     })
 
     it('get human stats', (done) => {
-      repo.stat({human: true}, (err, stats) => {
+      repo.stat({ human: true }, (err, stats) => {
         expect(err).to.not.exist()
         expect(stats).to.exist()
         expect(stats).to.have.property('numObjects')


### PR DESCRIPTION
This changes the blockstore to check for a CID of the other version (if applicable) when getting data or checking for existence.

If content is found for the other version of a CID then we `put` that block in the store under the passed CID. This causes some duplication.

When we migrate to using multihash as key instead of CID these duplicates will be purged.

FYI this is the same strategy that go-ipfs uses currently: https://github.com/ipfs/go-ipfs/pull/5285

~~depends on https://github.com/multiformats/js-cid/pull/71~~

Allows us to pass [these interop tests](https://github.com/ipfs/interop/pull/46):

<img width="306" alt="screenshot 2018-12-07 at 02 31 53" src="https://user-images.githubusercontent.com/152863/49624365-0dcbc180-f9c9-11e8-91b6-7f69c824c513.png">
