### PR TITLE
fix: fix repo lock and buffer api

### DIFF
--- a/src/lock.js
+++ b/src/lock.js
@@ -39,5 +39,8 @@ exports.lock = (dir, callback) => {
         }
       })
     })
-    .catch(err => callback(err))
+    .catch(err => {
+      log(err)
+      callback(err)
+    })
 }

--- a/src/lock.js
+++ b/src/lock.js
@@ -38,9 +38,8 @@ exports.lock = (dir, callback) => {
             .catch(err => cb(err))
         }
       })
-    })
+    }, callback)
     .catch(err => {
       log(err)
-      callback(err)
     })
 }


### PR DESCRIPTION
This PR makes the repo lock safer with callback/promise conversion, using then second arg we don't catch error inside the first arg fn and avoid callback already called errors.

Plus changes 2 two test to use the new buffer api. 