### PR TITLE
refactor: switch to bignumber.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "base32.js": "~0.1.0",
-    "big.js": "^5.2.2",
+    "bignumber.js": "^8.0.2",
     "cids": "~0.5.7",
     "datastore-core": "~0.6.0",
     "datastore-fs": "~0.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const _get = require('lodash.get')
 const assert = require('assert')
 const path = require('path')
 const debug = require('debug')
-const Big = require('big.js')
+const Big = require('bignumber.js')
 const pull = require('pull-stream')
 
 const backends = require('./backends')


### PR DESCRIPTION
A subset of https://github.com/ipfs/js-ipfs-repo/pull/186 - unfortunately this change was released as a patch version in other modules so I'm expediting it here so that js-ipfs can consistently return a bignumber.js not a big.js for both `stats.repo` and `stats.bw`.

bignumber.js is a drop in replacement for big.js with more functionality so you could consider this change a minor.