### PR TITLE
chore: update datastore-level

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cids": "~0.5.8",
     "datastore-core": "~0.6.0",
     "datastore-fs": "~0.8.0",
-    "datastore-level": "~0.10.0",
+    "datastore-level": "~0.11.0",
     "debug": "^4.1.0",
     "dlv": "^1.1.2",
     "interface-datastore": "~0.6.0",

--- a/test/lock-test.js
+++ b/test/lock-test.js
@@ -25,15 +25,14 @@ module.exports = (repo) => {
       ], done)
     })
 
-    it.only('should prevent multiple repos from using the same path', (done) => {
+    it('should prevent multiple repos from using the same path', (done) => {
       const repoClone = new IPFSRepo(repo.path, repo.options)
 
       // Levelup throws an uncaughtException when a lock already exists, catch it
       const mochaExceptionHandler = process.listeners('uncaughtException').pop()
       process.removeListener('uncaughtException', mochaExceptionHandler)
       process.once('uncaughtException', function (err) {
-        console.log('uncaughtException', err)
-        expect(err.message).to.match(/already held|IO error|already being hold/)
+        expect(err.message).to.match(/already held|IO error|already being held/)
       })
 
       series([
@@ -41,7 +40,6 @@ module.exports = (repo) => {
           try {
             repoClone.init({}, cb)
           } catch (err) {
-            console.log('caught', err)
             cb(err)
           }
         },
@@ -49,11 +47,9 @@ module.exports = (repo) => {
           repoClone.open(cb)
         }
       ], function (err) {
-        console.log('callback', err)
-
         // There will be no listeners if the uncaughtException was triggered
         if (process.listeners('uncaughtException').length > 0) {
-          expect(err.message).to.match(/already locked|already held|already being hold|ELOCKED/)
+          expect(err.message).to.match(/already locked|already held|already being held|ELOCKED/)
         }
 
         // Reset listeners to maintain test integrity

--- a/test/lock-test.js
+++ b/test/lock-test.js
@@ -25,13 +25,14 @@ module.exports = (repo) => {
       ], done)
     })
 
-    it('should prevent multiple repos from using the same path', (done) => {
+    it.only('should prevent multiple repos from using the same path', (done) => {
       const repoClone = new IPFSRepo(repo.path, repo.options)
 
       // Levelup throws an uncaughtException when a lock already exists, catch it
       const mochaExceptionHandler = process.listeners('uncaughtException').pop()
       process.removeListener('uncaughtException', mochaExceptionHandler)
       process.once('uncaughtException', function (err) {
+        console.log('uncaughtException', err)
         expect(err.message).to.match(/already held|IO error|already being hold/)
       })
 
@@ -40,6 +41,7 @@ module.exports = (repo) => {
           try {
             repoClone.init({}, cb)
           } catch (err) {
+            console.log('caught', err)
             cb(err)
           }
         },
@@ -47,6 +49,8 @@ module.exports = (repo) => {
           repoClone.open(cb)
         }
       ], function (err) {
+        console.log('callback', err)
+
         // There will be no listeners if the uncaughtException was triggered
         if (process.listeners('uncaughtException').length > 0) {
           expect(err.message).to.match(/already locked|already held|already being hold|ELOCKED/)


### PR DESCRIPTION
So we can get the benefits of https://github.com/ipfs/js-datastore-level/pull/15
