### PR TITLE
Memlock throws error when lock exists

### DIFF
--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,6 +1,21 @@
 'use strict'
 
 /**
+ * Error raised when there is lock already in place when repo is being opened.
+ */
+class LockExistsError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'LockExistsError'
+    this.code = 'ERR_LOCK_EXISTS'
+    this.message = message
+  }
+}
+
+LockExistsError.code = 'ERR_LOCK_EXISTS'
+exports.LockExistsError = LockExistsError
+
+/**
  * Error raised when requested item is not found.
  */
 class NotFoundError extends Error {

--- a/src/lock-memory.js
+++ b/src/lock-memory.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const errors = require('./errors')
 const debug = require('debug')
 
 const log = debug('repo:lock')
@@ -17,6 +18,11 @@ const LOCKS = {}
 exports.lock = async (dir) => { // eslint-disable-line require-await
   const file = dir + '/' + lockFile
   log('locking %s', file)
+
+  if (LOCKS[file] === true) {
+    throw new errors.LockExistsError(`Lock already being held for file: ${file}`)
+  }
+
   LOCKS[file] = true
   const closer = {
     async close () { // eslint-disable-line require-await

--- a/test/browser.js
+++ b/test/browser.js
@@ -23,4 +23,5 @@ describe('IPFS Repo Tests on the Browser', () => {
   require('./keystore-test')(repo)
   require('./config-test')(repo)
   require('./api-addr-test')(repo)
+  require('./lock-test')(repo)
 })

--- a/test/lock-test.js
+++ b/test/lock-test.js
@@ -41,16 +41,10 @@ module.exports = (repo) => {
   })
 
   describe('lock-memory', () => {
-    it('should lock a dir', async () => {
+    it('should lock and unlock dir', async () => {
       const dir = '/foo/bar'
       expect(await lockMemory.locked(dir)).to.be.false()
 
-      await lockMemory.lock(dir)
-      expect(await lockMemory.locked(dir)).to.be.true()
-    })
-
-    it('should unlock a dir', async () => {
-      const dir = '/foo/bar'
       const closer = await lockMemory.lock(dir)
       expect(await lockMemory.locked(dir)).to.be.true()
 


### PR DESCRIPTION
Memlock throws error when lock exists
Fix for memlock to throw an error when trying to acquire already
existing lock.

License: MIT
Signed-off-by: Adam Uhlir <uhlir.a@gmail.com>