### PR TITLE
feat: export blockstore key encode/decode utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Arguments:
     * `root` (defaults to [`datastore-fs`](https://github.com/ipfs/js-datastore-fs#readme) in Node.js and [`datastore-level`](https://github.com/ipfs/js-datastore-level#readme) in the browser). Defines the back-end type used for gets and puts of values at the root (`repo.set()`, `repo.get()`)
     * `blocks` (defaults to [`datastore-fs`](https://github.com/ipfs/js-datastore-fs#readme) in Node.js and [`datastore-level`](https://github.com/ipfs/js-datastore-level#readme) in the browser). Defines the back-end type used for gets and puts of values at `repo.blocks`.
     * `keys` (defaults to [`datastore-fs`](https://github.com/ipfs/js-datastore-fs#readme) in Node.js and [`datastore-level`](https://github.com/ipfs/js-datastore-level#readme) in the browser). Defines the back-end type used for gets and puts of encrypted keys at `repo.keys`
-    * `datastore` (defaults to [`datastore-level`](https://github.com/ipfs/js-datastore-level#readme)). Defines the back-end type used as the key-valye store used for gets and puts of values at `repo.datastore`.
+    * `datastore` (defaults to [`datastore-level`](https://github.com/ipfs/js-datastore-level#readme)). Defines the back-end type used as the key-value store used for gets and puts of values at `repo.datastore`.
 
 ```js
 const repo = new Repo('path/to/repo')

--- a/src/blockstore-utils.js
+++ b/src/blockstore-utils.js
@@ -1,0 +1,27 @@
+const base32 = require('base32.js')
+const { Key } = require('interface-datastore')
+const CID = require('cids')
+
+/**
+ * Transform a cid to the appropriate datastore key.
+ *
+ * @param {CID} cid
+ * @returns {Key}
+ */
+exports.cidToKey = cid => {
+  const enc = new base32.Encoder()
+  return new Key('/' + enc.write(cid.buffer).finalize(), false)
+}
+
+/**
+ * Transform a datastore Key instance to a CID
+ *
+ * @param {Key} key
+ * @returns {CID}
+ */
+exports.keyToCid = key => {
+  // Block key is of the form /<base32 encoded string>
+  const decoder = new base32.Decoder()
+  const buff = decoder.write(key.toString().slice(1)).finalize()
+  return new CID(Buffer.from(buff))
+}

--- a/src/blockstore-utils.js
+++ b/src/blockstore-utils.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const base32 = require('base32.js')
 const { Key } = require('interface-datastore')
 const CID = require('cids')

--- a/src/index.js
+++ b/src/index.js
@@ -298,6 +298,7 @@ async function getSize (queryFn) {
 }
 
 module.exports = IpfsRepo
+module.exports.utils = { blockstore: require('./blockstore-utils') }
 module.exports.repoVersion = repoVersion
 module.exports.errors = ERRORS
 

--- a/test/blockstore-utils-test.js
+++ b/test/blockstore-utils-test.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const { expect } = chai
+const { Key } = require('interface-datastore')
+const CID = require('cids')
+const Repo = require('../src')
+
+module.exports = () => {
+  describe('blockstore utils', () => {
+    it('converts a CID to a datastore Key and back', () => {
+      const originalCid = new CID('Qme6KJdKcp85TYbLxuLV7oQzMiLremD7HMoXLZEmgo6Rnh')
+      const key = Repo.utils.blockstore.cidToKey(originalCid)
+      expect(key instanceof Key).to.be.true()
+      const cid = Repo.utils.blockstore.keyToCid(key)
+      expect(cid instanceof CID).to.be.true()
+      expect(originalCid.toString()).to.equal(cid.toString())
+    })
+  })
+}

--- a/test/browser.js
+++ b/test/browser.js
@@ -19,6 +19,7 @@ describe('IPFS Repo Tests on the Browser', () => {
 
   require('./repo-test')(repo)
   require('./blockstore-test')(repo)
+  require('./blockstore-utils-test')()
   require('./datastore-test')(repo)
   require('./keystore-test')(repo)
   require('./config-test')(repo)

--- a/test/node.js
+++ b/test/node.js
@@ -103,4 +103,6 @@ describe('IPFS Repo Tests onNode.js', () => {
       require('./interop-test')(repo)
     }
   }))
+
+  require('./blockstore-utils-test')()
 })


### PR DESCRIPTION
These have already been duplicated twice in js-ipfs. This exposes utility functions to encode a CID as a blockstore Key and decode a blockstore Key to a CID.

refs https://github.com/ipfs/js-ipfs/pull/2022/files#r303389863