### PR TITLE
test: make stat test independent of other tests

### DIFF
--- a/test/stat-test.js
+++ b/test/stat-test.js
@@ -4,9 +4,19 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
+const Block = require('ipfs-block')
+const CID = require('cids')
 
 module.exports = (repo) => {
   describe('stat', () => {
+    before(async () => {
+      const data = new Block(
+        Buffer.from('foo'),
+        new CID('bafyreighz6vdlkdsvp4nu3lxhsofnk2eqxn6o57ag3mfxkqa7c327djhra')
+      )
+      await repo.blocks.put(data)
+    })
+
     it('get stats', async () => {
       const stats = await repo.stat()
       expect(stats).to.exist()


### PR DESCRIPTION
Prior to this change running only the stat tests via:

    npx mocha test/node.js --grep stats

would fail, as they expect to have data in the repo.