### PR TITLE
feat: accept async iterators into blockstore.putMany

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
 
 node_js:
   - '10'
+  - '12'
 
 os:
   - linux
@@ -20,7 +21,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Get a value at the root of the repo.
 
 Put many blocks.
 
-* `block` should be an array of type [Block](https://github.com/ipfs/js-ipfs-block#readme).
+* `block` should be an Iterable or AsyncIterable that yields entries of type [Block](https://github.com/ipfs/js-ipfs-block#readme).
 
 #### `Promise<Buffer> repo.blocks.get (cid)`
 

--- a/src/blockstore.js
+++ b/src/blockstore.js
@@ -85,7 +85,7 @@ function createBaseStore (store) {
     /**
      * Like put, but for more.
      *
-     * @param {AsyncIterable<Block>} blocks
+     * @param {AsyncIterable<Block>|Iterable<Block>} blocks
      * @returns {Promise<void>}
      */
     async putMany (blocks) {


### PR DESCRIPTION
Allows streaming into the blockstore. The blockstore currently uses the batch functionality of the underlying datatore, so we might need to change `interface-datastore` next to add streaming primitives but this at least allows streaming this far down the stack.

BREAKING CHANGE: you must pass an iterable or async iterable to putMany - this should be relatively painless as the current API is to pass an array which is iterable, but it does change the API and rules is rules.