### PR TITLE
Bumped p-queue to ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "just-safe-get": "^1.3.0",
     "just-safe-set": "^2.1.0",
     "lodash.has": "^4.5.2",
-    "p-queue": "^5.0.0",
+    "p-queue": "^6.0.0",
     "proper-lockfile": "^4.0.0",
     "sort-keys": "^3.0.0"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Key = require('interface-datastore').Key
-const Queue = require('p-queue')
+const { default: Queue } = require('p-queue')
 const _get = require('just-safe-get')
 const _set = require('just-safe-set')
 const _has = require('lodash.has')


### PR DESCRIPTION
## Changes
This bumps `p-queue` to ^6.0.0 to resolve `p-queue` version mismatch issues with `mortice` when using `ipfs` in Electron. 

## Relevant Issue
https://github.com/ipfs/js-ipfs/issues/2374