### PR TITLE
fix: pass backwards-compatible level-js options

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cids": "~0.7.0",
     "datastore-core": "~0.7.0",
     "datastore-fs": "~0.9.0",
-    "datastore-level": "~0.12.0",
+    "datastore-level": "~0.14.0",
     "debug": "^4.1.0",
     "err-code": "^1.1.2",
     "interface-datastore": "~0.7.0",

--- a/src/default-options-browser.js
+++ b/src/default-options-browser.js
@@ -24,6 +24,11 @@ module.exports = {
       sharding: false,
       prefix: '',
       version: 2
+    },
+    datastore: {
+      sharding: false,
+      prefix: '',
+      version: 2
     }
   }
 }

--- a/src/default-options-browser.js
+++ b/src/default-options-browser.js
@@ -11,13 +11,19 @@ module.exports = {
   },
   storageBackendOptions: {
     root: {
-      extension: ''
+      extension: '',
+      prefix: '',
+      version: 2
     },
     blocks: {
-      sharding: false
+      sharding: false,
+      prefix: '',
+      version: 2
     },
     keys: {
-      sharding: false
+      sharding: false,
+      prefix: '',
+      version: 2
     }
   }
 }

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -65,32 +65,9 @@ describe('custom options tests', () => {
 function noop () {}
 
 function expectedRepoOptions () {
-  const options = {
-    lock: process.browser ? 'memory' : 'fs',
-    storageBackends: {
-      // packages are exchanged to browser-compatible
-      // equivalents via package.browser
-      root: require('datastore-fs'),
-      blocks: require('datastore-fs'),
-      keys: require('datastore-fs'),
-      datastore: require('datastore-level')
-    },
-    storageBackendOptions: {
-      root: {
-        extension: ''
-      },
-      keys: {},
-      blocks: {
-        sharding: true,
-        extension: '.data'
-      }
-    }
+  if (process.browser) {
+    return require('../src/default-options-browser')
   }
 
-  if (process.browser) {
-    options.storageBackendOptions.keys.sharding = false
-    delete options.storageBackendOptions.blocks.extension
-    options.storageBackendOptions.blocks.sharding = false
-  }
-  return options
+  return require('../src/default-options')
 }


### PR DESCRIPTION
Between `level-js@2` and `level-js@4` it started passing version numbers into  `indexedDB.open` so we have to specify these now.  It also prefixes locations with a disambiguator, which we need to set to blank for browsers to still be able to read their previously created databases.

Depends on:

- [x] https://github.com/Level/packager/pull/96
- [x] https://github.com/Level/level-js/pull/184
- ~[ ] https://github.com/ipfs/js-ipfs-repo/pull/217~