### PR TITLE
feat: remove options object from stat method

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,9 @@ Sets the API address.
 
 * `value` should be a [Multiaddr](https://github.com/multiformats/js-multiaddr) or a String representing a valid one.
 
-### `Promise<Object> repo.stat ([options])`
+### `Promise<Object> repo.stat ()`
 
 Gets the repo status.
-
-`options` is an object which might contain the key `human`, which is a boolean indicating whether or not the `repoSize` should be displayed in MiB or not.
 
 Returned promise resolves to an `Object` with the following keys:
 
@@ -322,7 +320,7 @@ Returned promise resolves to a `boolean` indicating the existence of the lock.
 
 ### Migrations
 
-When there is a new repo migration and the version of repo is increased, don't 
+When there is a new repo migration and the version of repo is increased, don't
 forget to propagate the changes into the test repo (`test/test-repo`).
 
 **For tools that run mainly in the browser environment, be aware that disabling automatic

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "just-safe-set": "^2.1.0",
     "lodash.has": "^4.5.2",
     "p-queue": "^6.0.0",
-    "pretty-bytes": "^5.3.0",
     "proper-lockfile": "^4.0.0",
     "sort-keys": "^3.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ const debug = require('debug')
 const Big = require('bignumber.js')
 const errcode = require('err-code')
 const migrator = require('ipfs-repo-migrations')
-const prettyBytes = require('pretty-bytes')
 const bytes = require('bytes')
 
 const constants = require('./constants')
@@ -247,12 +246,9 @@ class IpfsRepo {
   /**
    * Get repo status.
    *
-   * @param {Object}  options
-   * @param {Boolean} options.human
-   * @return {Object}
+   * @returns {Object}
    */
-  async stat (options) {
-    options = Object.assign({}, { human: false }, options)
+  async stat () {
     const [storageMax, blocks, version, datastore, keys] = await Promise.all([
       this._storageMaxStat(),
       this._blockStat(),
@@ -266,16 +262,10 @@ class IpfsRepo {
 
     return {
       repoPath: this.path,
-      storageMax: options.human
-        ? prettyBytes(storageMax.toNumber()).toUpperCase()
-        : storageMax,
+      storageMax,
       version: version,
-      numObjects: options.human
-        ? blocks.count.toNumber()
-        : blocks.count,
-      repoSize: options.human
-        ? prettyBytes(size.toNumber()).toUpperCase()
-        : size
+      numObjects: blocks.count,
+      repoSize: size
     }
   }
 

--- a/test/stat-test.js
+++ b/test/stat-test.js
@@ -6,7 +6,6 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const Block = require('ipfs-block')
 const CID = require('cids')
-const prettyBytes = require('pretty-bytes')
 
 module.exports = (repo) => {
   describe('stat', () => {
@@ -31,26 +30,6 @@ module.exports = (repo) => {
       expect(stats.version > '0').to.eql(true)
       expect(stats.repoSize > '0').to.eql(true)
       expect(stats.storageMax > '0').to.eql(true)
-    })
-
-    it('get human stats', async () => {
-      const { repoSize, storageMax } = await repo.stat()
-
-      const humanizedRepoSize = prettyBytes(repoSize.toNumber()).toUpperCase()
-      const humanizedStorageMax = prettyBytes(storageMax.toNumber()).toUpperCase()
-
-      const humanizedStats = await repo.stat({ human: true })
-
-      expect(humanizedStats).to.exist()
-      expect(humanizedStats).to.have.property('numObjects')
-      expect(humanizedStats).to.have.property('version').and.be.above(0)
-      expect(humanizedStats).to.have.property('repoPath')
-      expect(humanizedStats).to.have.property('repoSize').that.equals(humanizedRepoSize)
-      expect(humanizedStats).to.have.property('storageMax').that.equals(humanizedStorageMax)
-
-      expect(humanizedStats.numObjects > '0').to.eql(true)
-      expect(humanizedStats.repoSize > '0').to.eql(true)
-      expect(humanizedStats.storageMax > '0').to.eql(true)
     })
   })
 }


### PR DESCRIPTION
`stat()` method was accepting an object called `options`. The only option available was `human` that was changing the stats' output to be human-readable. 

`human` option was just a formatting functionality and it should be kept out of `ipfs-core`. See https://github.com/ipfs/js-ipfs-repo/pull/213#issuecomment-555488344 for further details.

Thus, this PR removes the `options` object.