### PR TITLE
feat: add isInitialized method

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Get a value at the root of the repo.
 
 [Blocks](https://github.com/ipfs/js-ipfs-block#readme):
 
+#### `Promise<Boolean> repo.isInitialized ()`
+
+The returned promise resolves to `false` if the repo has not been initialized and `true` if it has.
+
 #### `Promise repo.blocks.put (block:Block)`
 
 * `block` should be of type [Block](https://github.com/ipfs/js-ipfs-block#readme).

--- a/src/index.js
+++ b/src/index.js
@@ -74,13 +74,21 @@ class IpfsRepo {
    * @returns {Promise<Boolean>}
    */
   async isInitialized () {
+    if (!this.closed) {
+      // repo is open, must be initialized
+      return true
+    }
+
     try {
+      // have to open the root datastore in the browser before
+      // we can check whether it's been initialized
       await this._openRoot()
       await this._checkInitialized()
-      // necessary? await this.root.close()
+      await this.root.close()
 
       return true
     } catch (err) {
+      // FIXME: do not use exceptions for flow control
       return false
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,22 @@ class IpfsRepo {
   }
 
   /**
+   * Check if the repo is already initialized.
+   * @returns {Promise<Boolean>}
+   */
+  async isInitialized () {
+    try {
+      await this._openRoot()
+      await this._checkInitialized()
+      // necessary? await this.root.close()
+
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+
+  /**
    * Open the repo. If the repo is already open an error will be thrown.
    * If the repo is not initialized it will throw an error.
    *

--- a/test/browser.js
+++ b/test/browser.js
@@ -38,4 +38,5 @@ describe('IPFS Repo Tests on the Browser', () => {
   require('./config-test')(repo)
   require('./api-addr-test')(repo)
   require('./lock-test')(repo)
+  require('./is-initialized')
 })

--- a/test/is-initialized.js
+++ b/test/is-initialized.js
@@ -1,0 +1,28 @@
+/* eslint max-nested-callbacks: ["error", 8] */
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const os = require('os')
+const path = require('path')
+const IPFSRepo = require('../src')
+
+describe('isInitialized', () => {
+  let repo
+
+  beforeEach(() => {
+    const repoPath = path.join(os.tmpdir(), 'test-repo-for-' + Math.random())
+    repo = new IPFSRepo(repoPath)
+  })
+
+  it('should be false before initialization', async () => {
+    expect(await repo.isInitialized()).to.be.false()
+  })
+
+  it('should be true after initialization', async () => {
+    await repo.init({})
+    expect(await repo.isInitialized()).to.be.true()
+  })
+})

--- a/test/is-initialized.js
+++ b/test/is-initialized.js
@@ -25,4 +25,17 @@ describe('isInitialized', () => {
     await repo.init({})
     expect(await repo.isInitialized()).to.be.true()
   })
+
+  it('should be true after initialization and opening', async () => {
+    await repo.init({})
+    await repo.open()
+    expect(await repo.isInitialized()).to.be.true()
+  })
+
+  it('should be true after initialization, opening and closing', async () => {
+    await repo.init({})
+    await repo.open()
+    await repo.close()
+    expect(await repo.isInitialized()).to.be.true()
+  })
 })

--- a/test/node.js
+++ b/test/node.js
@@ -113,6 +113,7 @@ describe('IPFS Repo Tests onNode.js', () => {
     if (!r.init) {
       require('./interop-test')(repo)
     }
+    require('./is-initialized')
   }))
 
   require('./blockstore-utils-test')()


### PR DESCRIPTION
A few places need ot know whether or not a repo has been initialised and do so by a variety of methods - checking whether certain files exist, etc.

This PR adds an `isInitialized()` method to the ipfs repo class to take some of this guesswork away as the repo will know if it's been initialised.