### PR TITLE
feat: add deleteMany method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This is the implementation of the [IPFS repo spec](https://github.com/ipfs/specs
     - [`Promise repo.blocks.put (block:Block)`](#promise-repoblocksput-blockblock)
     - [`Promise repo.blocks.putMany (blocks)`](#promise-repoblocksputmany-blocks)
     - [`Promise<Buffer> repo.blocks.get (cid)`](#promisebuffer-repoblocksget-cid)
+    - [`Promise repo.blocks.delete (cid:CID)`](#promise-repoblocksdelete-cidcid)
+    - [`Promise repo.blocks.deleteMany (cids)`](#promise-repoblocksdeletemany-cids)
     - [`repo.datastore`](#repodatastore)
   - [Config](#config)
     - [`Promise repo.config.set(key:string, value)`](#promise-repoconfigsetkeystring-value)
@@ -235,6 +237,18 @@ Put many blocks.
 Get block.
 
 * `cid` is the content id of [type CID](https://github.com/ipld/js-cid#readme).
+
+#### `Promise repo.blocks.delete (cid:CID)`
+
+* `cid` should be of the [type CID](https://github.com/ipld/js-cid#readme).
+
+Delete a block
+
+#### `Promise repo.blocks.deleteMany (cids)`
+
+* `cids` should be an Iterable or AsyncIterable that yields entries of the [type CID](https://github.com/ipld/js-cid#readme).
+
+Delete many blocks
 
 Datastore:
 

--- a/src/blockstore-utils.js
+++ b/src/blockstore-utils.js
@@ -3,6 +3,7 @@
 const { Key } = require('interface-datastore')
 const CID = require('cids')
 const multibase = require('multibase')
+const errcode = require('err-code')
 
 /**
  * Transform a cid to the appropriate datastore key.
@@ -11,6 +12,10 @@ const multibase = require('multibase')
  * @returns {Key}
  */
 exports.cidToKey = cid => {
+  if (!CID.isCID(cid)) {
+    throw errcode(new Error('Not a valid cid'), 'ERR_INVALID_CID')
+  }
+
   return new Key('/' + multibase.encode('base32', cid.buffer).toString().slice(1).toUpperCase(), false)
 }
 

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -281,5 +281,17 @@ module.exports = (repo) => {
         return expect(repo.blocks.delete('foo')).to.eventually.be.rejected().with.property('code', 'ERR_INVALID_CID')
       })
     })
+
+    describe('.deleteMany', () => {
+      it('simple', async () => {
+        await repo.blocks.deleteMany([b.cid])
+        const exists = await repo.blocks.has(b.cid)
+        expect(exists).to.equal(false)
+      })
+
+      it('throws when passed an invalid cid', () => {
+        return expect(repo.blocks.deleteMany(['foo'])).to.eventually.be.rejected().with.property('code', 'ERR_INVALID_CID')
+      })
+    })
   })
 }


### PR DESCRIPTION
Similar to `repo.blocks.putMany` this adds a `repo.blocks.deleteMany` method that allows for deleting lots of blocks in one go.