### PR TITLE
docs: update architecture diagram in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Here is the architectural reasoning for this repo:
             ┌─────────────────┐                                 ┌─────────────────┐
             │        /        │                                 │        /        │
             ├─────────────────┤                                 ├─────────────────┤
-            │   FsDatastore   │                                 │LevelJSDatastore │
+            │   FsDatastore   │                                 │  IdbDatastore   │
             └─────────────────┘                                 └─────────────────┘
          ┌───────────┴───────────┐                           ┌───────────┴───────────┐
 ┌─────────────────┐     ┌─────────────────┐         ┌─────────────────┐     ┌─────────────────┐
 │     /blocks     │     │   /datastore    │         │     /blocks     │     │   /datastore    │
 ├─────────────────┤     ├─────────────────┤         ├─────────────────┤     ├─────────────────┤
-│ FlatfsDatastore │     │LevelDBDatastore │         │LevelJSDatastore │     │LevelJSDatastore │
+│ FlatfsDatastore │     │LevelDBDatastore │         │  IdbDatastore   │     │  IdbDatastore   │
 └─────────────────┘     └─────────────────┘         └─────────────────┘     └─────────────────┘
 ```
 


### PR DESCRIPTION
We switched from datastore-level-js to datastore-idb in `2.0.0` so update the diagram to reflect that.