### PR TITLE
feat: use datastore-level in the browser again

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "browser": {
     "rimraf": false,
-    "datastore-fs": "datastore-idb",
+    "datastore-fs": "datastore-level",
     "./src/lock.js": "./src/lock-memory.js",
     "./src/default-options.js": "./src/default-options-browser.js"
   },
@@ -65,7 +65,6 @@
     "cids": "^0.8.0",
     "datastore-core": "^1.1.0",
     "datastore-fs": "^1.1.0",
-    "datastore-idb": "^1.1.0",
     "datastore-level": "^1.1.0",
     "debug": "^4.1.0",
     "err-code": "^2.0.0",

--- a/src/default-options-browser.js
+++ b/src/default-options-browser.js
@@ -4,10 +4,10 @@
 module.exports = {
   lock: 'memory',
   storageBackends: {
-    root: require('datastore-idb'),
-    blocks: require('datastore-idb'),
-    keys: require('datastore-idb'),
-    datastore: require('datastore-idb')
+    root: require('datastore-level'),
+    blocks: require('datastore-level'),
+    keys: require('datastore-level'),
+    datastore: require('datastore-level')
   },
   storageBackendOptions: {
     root: {


### PR DESCRIPTION
`level-js` seems to handle datastore mutations during queries better which we need for datastore migrations.

Revisit once https://github.com/ipfs/js-datastore-idb/issues/6 is resolved.