### PR TITLE
chore: remove redundant chai deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
   },
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
-    "dirty-chai": "^2.0.1",
     "it-all": "^1.0.2",
     "it-drain": "^1.0.1",
     "it-first": "^1.0.2",

--- a/test/api-addr-test.js
+++ b/test/api-addr-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const apiAddr = require('../src/api-addr')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const Block = require('ipld-block')
 const CID = require('cids')
 const range = require('just-range')

--- a/test/blockstore-utils-test.js
+++ b/test/blockstore-utils-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const { Key } = require('interface-datastore')
 const CID = require('cids')
 const Repo = require('../src')

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 
 module.exports = (repo) => {
   describe('config', () => {

--- a/test/datastore-test.js
+++ b/test/datastore-test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const range = require('just-range')
 const Key = require('interface-datastore').Key
 const uint8ArrayFromString = require('uint8arrays/from-string')

--- a/test/interop-test.js
+++ b/test/interop-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const mh = require('multihashing-async').multihash
 const CID = require('cids')
 const Key = require('interface-datastore').Key

--- a/test/is-initialized.js
+++ b/test/is-initialized.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const tempDir = require('ipfs-utils/src/temp-dir')
 const IPFSRepo = require('../src')
 

--- a/test/keystore-test.js
+++ b/test/keystore-test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 
 module.exports = (repo) => {
   describe('keystore', () => {

--- a/test/lock-test.js
+++ b/test/lock-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const IPFSRepo = require('../')
 const lockMemory = require('../src/lock-memory')
 const { LockExistsError } = require('./../src/errors')

--- a/test/migrations-test.js
+++ b/test/migrations-test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
 
 const migrator = require('ipfs-repo-migrations')

--- a/test/node.js
+++ b/test/node.js
@@ -9,8 +9,6 @@ const promisify = require('util').promisify
 const os = require('os')
 const { LockExistsError } = require('../src/errors')
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
 
 const asyncRimraf = promisify(rimraf)
 const asyncNcp = promisify(ncp)

--- a/test/node.js
+++ b/test/node.js
@@ -9,7 +9,6 @@ const promisify = require('util').promisify
 const os = require('os')
 const { LockExistsError } = require('../src/errors')
 
-
 const asyncRimraf = promisify(rimraf)
 const asyncNcp = promisify(ncp)
 const fsstat = promisify(fs.stat)

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const tempDir = require('ipfs-utils/src/temp-dir')
 const { isNode } = require('ipfs-utils/src/env')
 const rimraf = require('rimraf')

--- a/test/pins-test.js
+++ b/test/pins-test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const range = require('just-range')
 const Key = require('interface-datastore').Key
 const uint8ArrayFromString = require('uint8arrays/from-string')

--- a/test/repo-test.js
+++ b/test/repo-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const tempDir = require('ipfs-utils/src/temp-dir')
 const IPFSRepo = require('../')
 const Errors = require('../src/errors')

--- a/test/stat-test.js
+++ b/test/stat-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const { expect } = require('./utils/chai')
+const { expect } = require('aegir/utils/chai')
 const Block = require('ipld-block')
 const CID = require('cids')
 const uint8ArrayFromString = require('uint8arrays/from-string')

--- a/test/utils/chai.js
+++ b/test/utils/chai.js
@@ -1,9 +1,0 @@
-'use strict'
-
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-chai.use(require('chai-as-promised'))
-
-module.exports = {
-  expect: chai.expect
-}


### PR DESCRIPTION
chai is bundled & configured by aegir so we don't need to depend on
it separately.