### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^28.1.0",
     "it-all": "^1.0.2",
     "it-drain": "^1.0.1",
     "it-first": "^1.0.2",
@@ -65,8 +65,8 @@
     "err-code": "^2.0.0",
     "interface-datastore": "^2.0.0",
     "ipfs-repo-migrations": "^5.0.3",
-    "ipfs-utils": "^2.3.1",
-    "ipld-block": "^0.10.0",
+    "ipfs-utils": "^4.0.0",
+    "ipld-block": "^0.11.0",
     "it-map": "^1.0.2",
     "it-pushable": "^1.4.0",
     "just-safe-get": "^2.0.0",

--- a/src/api-addr.js
+++ b/src/api-addr.js
@@ -10,7 +10,7 @@ module.exports = (store) => {
     /**
      * Get the current configuration from the repo.
      *
-     * @returns {Promise<String>}
+     * @returns {Promise<string>}
      */
     async get () {
       const value = await store.get(apiFile)

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ module.exports = (store) => {
     /**
      * Get the value for the passed configuration key from the repo.
      *
-     * @param {String} key - the config key to get
+     * @param {string} key - the config key to get
      * @param {Object} options - options
      * @param {AbortSignal} options.signal - abort this config read
      * @returns {Promise<Object>}
@@ -57,7 +57,7 @@ module.exports = (store) => {
     /**
      * Set the current configuration for this repo.
      *
-     * @param {String} key - the config key to be written
+     * @param {string} key - the config key to be written
      * @param {Object} value - the config value to be written
      * @param {Object} options - options
      * @param {AbortSignal} options.signal - abort this config write

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const lockers = {
  */
 class IpfsRepo {
   /**
-   * @param {String} repoPath - path where the repo is stored
+   * @param {string} repoPath - path where the repo is stored
    * @param {Object} options - Configuration
    */
   constructor (repoPath, options) {
@@ -71,7 +71,8 @@ class IpfsRepo {
 
   /**
    * Check if the repo is already initialized.
-   * @returns {Promise<Boolean>}
+   *
+   * @returns {Promise<boolean>}
    */
   async isInitialized () {
     if (!this.closed) {
@@ -174,6 +175,7 @@ class IpfsRepo {
 
   /**
    * Opens the root backend, catching and ignoring an 'Already open' error
+   *
    * @returns {Promise}
    */
   async _openRoot () {
@@ -190,7 +192,7 @@ class IpfsRepo {
    * Creates a lock on the repo if a locker is specified. The lockfile object will
    * be returned in the callback if one has been created.
    *
-   * @param {String} path
+   * @param {string} path
    * @returns {Promise<lockfile>}
    */
   async _openLock (path) {
@@ -214,6 +216,7 @@ class IpfsRepo {
 
   /**
    * Check if the repo is already initialized.
+   *
    * @private
    * @returns {Promise}
    */

--- a/src/lock-memory.js
+++ b/src/lock-memory.js
@@ -12,7 +12,7 @@ const LOCKS = {}
 /**
  * Lock the repo in the given dir.
  *
- * @param {String} dir
+ * @param {string} dir
  * @returns {Promise<Object>}
  */
 exports.lock = async (dir) => { // eslint-disable-line require-await
@@ -37,7 +37,7 @@ exports.lock = async (dir) => { // eslint-disable-line require-await
 /**
  * Check if the repo in the given directory is locked.
  *
- * @param {String} dir
+ * @param {string} dir
  * @returns {bool}
  */
 exports.locked = async (dir) => { // eslint-disable-line require-await

--- a/src/lock.js
+++ b/src/lock.js
@@ -10,6 +10,7 @@ const lockFile = 'repo.lock'
 
 /**
  * Duration in milliseconds in which the lock is considered stale
+ *
  * @see https://github.com/moxystudio/node-proper-lockfile#lockfile-options
  * The default value of 10000 was too low for ipfs and sometimes `proper-lockfile`
  * would throw an exception because it couldn't update the lock file mtime within
@@ -22,7 +23,7 @@ const STALE_TIME = 20000
 /**
  * Lock the repo in the given dir.
  *
- * @param {String} dir
+ * @param {string} dir
  * @returns {Promise<Object>}
  */
 exports.lock = async (dir) => {

--- a/src/spec.js
+++ b/src/spec.js
@@ -29,6 +29,7 @@ module.exports = (store) => {
     /**
      * Set the datastore spec of the repo, writing it to the underlying store.
      * TODO unclear on what the type should be or if it's required
+     *
      * @param {number} spec
      * @returns {Promise<void>}
      */

--- a/src/version.js
+++ b/src/version.js
@@ -38,6 +38,7 @@ module.exports = (store) => {
     },
     /**
      * Check the current version, and returns true if versions matches
+     *
      * @param {number} expected
      * @returns {boolean}
      */


### PR DESCRIPTION
BREAKING CHANGE: updates ipld-block to 0.11.0 which is not compatible with earlier versions (fails `expect(v11Block).to.deep.equal(v10Block)` for example)