### PR TITLE
chore: add config keys for Announce and NoAnnounce addresses

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -135,7 +135,9 @@ export interface AddressConfig {
   RPC?: string
   Delegates?: string[]
   Gateway?: string
-  Swarm?: string[]
+  Swarm?: string[],
+  Announce: string[],
+  NoAnnounce: string[]
 }
 
 export interface APIConfig {


### PR DESCRIPTION
These were missing from the types