### PR TITLE
fix: return type of deleteMany should be the cids you deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "ipfs-utils": "^6.0.0",
     "ipld-block": "^0.11.0",
     "it-filter": "^1.0.2",
-    "it-map": "^1.0.2",
     "it-pushable": "^1.4.0",
     "just-safe-get": "^2.0.0",
     "just-safe-set": "^2.1.0",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -105,7 +105,7 @@ export interface Blockstore {
   /**
    * Delete a block from the store
    */
-  deleteMany: (cids: AwaitIterable<any>, options?: DatastoreOptions) => AsyncIterable<Key>
+  deleteMany: (cids: AwaitIterable<any>, options?: DatastoreOptions) => AsyncIterable<CID>
 
   /**
    * Close the store

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -440,9 +440,11 @@ module.exports = (repo) => {
 
     describe('.deleteMany', () => {
       it('simple', async () => {
-        await drain(repo.blocks.deleteMany([b.cid]))
+        const deleted = await all(repo.blocks.deleteMany([b.cid]))
         const exists = await repo.blocks.has(b.cid)
         expect(exists).to.equal(false)
+        expect(deleted).to.have.lengthOf(1)
+        expect(deleted[0]).to.deep.equal(b.cid)
       })
 
       it('including identity cid', async () => {


### PR DESCRIPTION
It should not leak datastore keys, instead return the cids you deleted.

Lets us not depend on ipfs-repo or interface-datastore in the types of
ipfs-blockstore, then ipld, then ipfs-http-client.