### PR TITLE
fix: access process from globalThis

### DIFF
--- a/packages/ipfs-repo/src/idstore.js
+++ b/packages/ipfs-repo/src/idstore.js
@@ -67,7 +67,7 @@ export function createIdStore (store) {
 
       // process.nextTick runs on the microtask queue, setImmediate runs on the next
       // event loop iteration so is slower. Use process.nextTick if it is available.
-      const runner = globalThis.process && globalThis.process.nextTick ? globalThis.process.nextTick : setImmediate
+      const runner = globalThis.process && globalThis.process.nextTick ? globalThis.process.nextTick : (globalThis.setImmediate || globalThis.setTimeout)
 
       runner(async () => {
         try {

--- a/packages/ipfs-repo/src/idstore.js
+++ b/packages/ipfs-repo/src/idstore.js
@@ -67,7 +67,7 @@ export function createIdStore (store) {
 
       // process.nextTick runs on the microtask queue, setImmediate runs on the next
       // event loop iteration so is slower. Use process.nextTick if it is available.
-      const runner = process && process.nextTick ? process.nextTick : setImmediate
+      const runner = globalThis.process && globalThis.process.nextTick ? globalThis.process.nextTick : setImmediate
 
       runner(async () => {
         try {


### PR DESCRIPTION
Fixes webpack error:

```
Module not found: Error: Can't resolve 'process/browser' in /path/...
```

Falls back to `setImmediate`, then `setTimeout`.