### PR TITLE
fix: OOM on large DAGs

### DIFF
--- a/packages/ipfs-repo-migrations/src/index.js
+++ b/packages/ipfs-repo-migrations/src/index.js
@@ -43,8 +43,11 @@ export function getLatestMigrationVersion (migrations) {
  * @param {number} toVersion - Version to which the repo should be migrated.
  * @param {MigrationOptions} [options] - Options for migration
  */
-export async function migrate (path, backends, repoOptions, toVersion, { ignoreLock = false, onProgress, isDryRun = false, migrations }) {
-  migrations = migrations || defaultMigrations
+export async function migrate (path, backends, repoOptions, toVersion, options = {}) {
+  const ignoreLock = options.ignoreLock ?? false
+  const onProgress = options.onProgress
+  const isDryRun = options.isDryRun ?? false
+  const migrations = options.migrations ?? defaultMigrations
 
   if (!path) {
     throw new errors.RequiredParameterError('Path argument is required!')
@@ -143,8 +146,11 @@ export async function migrate (path, backends, repoOptions, toVersion, { ignoreL
  * @param {number} toVersion - Version to which the repo will be reverted.
  * @param {MigrationOptions} [options] - Options for the reversion
  */
-export async function revert (path, backends, repoOptions, toVersion, { ignoreLock = false, onProgress, isDryRun = false, migrations }) {
-  migrations = migrations || defaultMigrations
+export async function revert (path, backends, repoOptions, toVersion, options = {}) {
+  const ignoreLock = options.ignoreLock ?? false
+  const onProgress = options.onProgress
+  const isDryRun = options.isDryRun ?? false
+  const migrations = options.migrations ?? defaultMigrations
 
   if (!path) {
     throw new errors.RequiredParameterError('Path argument is required!')

--- a/packages/ipfs-repo-migrations/src/index.js
+++ b/packages/ipfs-repo-migrations/src/index.js
@@ -1,4 +1,4 @@
-/* eslint complexity: ["error", 27] */
+/* eslint complexity: ["error", 28] */
 
 import defaultMigrations from '../migrations/index.js'
 import * as repoVersion from './repo/version.js'

--- a/packages/ipfs-repo/package.json
+++ b/packages/ipfs-repo/package.json
@@ -204,6 +204,7 @@
     "multiformats": "^9.0.4",
     "p-queue": "^7.3.0",
     "proper-lockfile": "^4.0.0",
+    "quick-lru": "^6.1.1",
     "sort-keys": "^5.0.0",
     "uint8arrays": "^3.0.0"
   },

--- a/packages/ipfs-repo/src/pin-manager.js
+++ b/packages/ipfs-repo/src/pin-manager.js
@@ -274,19 +274,11 @@ export class PinManager {
    * @param {AbortOptions} options
    */
   async fetchCompleteDag (cid, options) {
-    const seen = new Set()
-
     /**
      * @param {CID} cid
      * @param {AbortOptions} options
      */
     const walkDag = async (cid, options) => {
-      if (seen.has(cid.toString())) {
-        return
-      }
-
-      seen.add(cid.toString())
-
       const bytes = await this.blockstore.get(cid, options)
       const codec = await this.loadCodec(cid.code)
       const block = createUnsafe({ bytes, cid, codec })

--- a/packages/ipfs-repo/test/pins-test.js
+++ b/packages/ipfs-repo/test/pins-test.js
@@ -115,15 +115,17 @@ export default (repo) => {
         await repo.blocks.put(childCid, childBuf)
 
         // create a root block with duplicate links to the same block
-        const { cid: rootCid, buf: rootBuf } = await createDagPbNode({ Links: [{
-          Name: 'child-1',
-          Tsize: childBuf.byteLength,
-          Hash: childCid
-        }, {
-          Name: 'child-2',
-          Tsize: childBuf.byteLength,
-          Hash: childCid
-        }]})
+        const { cid: rootCid, buf: rootBuf } = await createDagPbNode({
+          Links: [{
+            Name: 'child-1',
+            Tsize: childBuf.byteLength,
+            Hash: childCid
+          }, {
+            Name: 'child-2',
+            Tsize: childBuf.byteLength,
+            Hash: childCid
+          }]
+        })
         await repo.blocks.put(rootCid, rootBuf)
 
         await repo.pins.pinRecursively(rootCid)


### PR DESCRIPTION
Storing a set of seen CIDs to short-cut DAG traversal while ensuring we have all the blocks in a DAG in the blockstore can cause OOMs for very large DAGs so replace the unbounded `Set` with a `LRU` cache with a configurable maximum size.